### PR TITLE
fix mint.json

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -164,15 +164,15 @@
     },
     {
       "source": "/sophon/introduction/sophon-token-usdsoph",
-      "destination": "/tokenomics/intro"
+      "destination": "/tokenomics/soph"
     },
     {
       "source": "/sophon/introduction/sophon-token-usdsoph/token-distribution",
-      "destination": "/tokenomics/intro"
+      "destination": "/tokenomics/soph"
     },
     {
       "source": "/sophon/building-and-interacting/getting-started",
-      "destination": "/build/getting-started"
+      "destination": "/build/start-building"
     },
     {
       "source": "/sophon/building-and-interacting/launching-on-sophon",
@@ -224,7 +224,7 @@
     },
     {
       "source": "/sophon/sophon-guardians-and-nodes/overview",
-      "destination": "/nodes/nodes-intro"
+      "destination": "/nodes/our-infra"
     },
     {
       "source": "/sophon/sophon-guardians-and-nodes/sophon-guardian-membership",


### PR DESCRIPTION
 Fix Redirect Links in Documentation

Fixed broken redirects in `mint.json`:
- `/tokenomics/intro` → `/tokenomics/soph`
- `/build/getting-started` → `/build/start-building`
- `/nodes/nodes-intro` → `/nodes/our-infra`

These changes align redirects with existing file structure to prevent 404 errors.