### PR TITLE
Added correct deployment parameters and async wrapper for Deployment with Paymaster

### DIFF
--- a/build/interact/hardhat.mdx
+++ b/build/interact/hardhat.mdx
@@ -115,28 +115,39 @@ const contract = await deployer.deploy(
 During the alpha stage, you'll need to use our Paymaster to sponsor transactions. Here's how to deploy using the paymaster:
 
 ```typescript
-import { utils } from "zksync-ethers";
+import { Provider, Wallet, utils } from "zksync-ethers";
+import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const deployer = new Deployer(hre, wallet);
-const artifact = await deployer.loadArtifact("Your_Contract");
+export default async function(hre: HardhatRuntimeEnvironment) {
+    const provider = new Provider(hre.network.config.url);
+    const wallet = new Wallet(process.env.WALLET_PRIVATE_KEY!, provider);
+    const deployer = new Deployer(hre, wallet);
+    const artifact = await deployer.loadArtifact("your_contract");
 
-const params = utils.getPaymasterParams(
-  "0x98546B226dbbA8230cf620635a1e4ab01F6A99B2", // Paymaster address
-  {
-    type: "General",
-    innerInput: new Uint8Array(),
-  }
-);
+ 
 
-const contract = await deployer.deploy(
-    artifact,
-    constructorArguments || [], 
-    {
-      customData: {
-        paymasterParams: params,
-        gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
-    },
-});
+    const params = utils.getPaymasterParams(
+      "0x98546B226dbbA8230cf620635a1e4ab01F6A99B2", // Paymaster address
+      {
+        type: "General",
+        innerInput: new Uint8Array(),
+      }
+    );
+
+
+    const contract = await deployer.deploy(
+      artifact,
+      [], // Constructor arguments
+      undefined, // Deployment type (omit or use undefined for regular contract deployment)
+      {
+          customData: {
+              paymasterParams: params,
+              gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          }
+      }
+  );
+}
 ```
 
 ### Proxy Deployment

--- a/build/interact/hardhat.mdx
+++ b/build/interact/hardhat.mdx
@@ -139,7 +139,7 @@ export default async function(hre: HardhatRuntimeEnvironment) {
     const contract = await deployer.deploy(
       artifact,
       [], // Constructor arguments
-      undefined, // Deployment type (omit or use undefined for regular contract deployment)
+      undefined, // Deployment type (use undefined for regular contract deployment)
       {
           customData: {
               paymasterParams: params,


### PR DESCRIPTION
Important Changes:
1. The deployment type parameter must be explicitly specified and cannot be omitted, otherwise the customData gets misinterpreted as the deployment type, causing the error:
```ts
// Wrong:
await deployer.deploy(
    artifact,
    [], 
    {
        customData: {  // This gets mistaken as deployment type!
            paymasterParams: params,
            gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
        }
    }
);

// Correct:
await deployer.deploy(
    artifact,
    [], 
    undefined,  // Explicit deployment type parameter
    {
        customData: {
            paymasterParams: params,
            gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
        }
    }
);
```
2. Adding the async function wrapper (required for await to work)

Minor Changes:

- Use of environment variable for private key (process.env.WALLET_PRIVATE_KEY)
- Added TypeScript types and imports
- Code formatting and structure improvements