### PR TITLE
refactor: update documentation structure and fix links in badges section

### DIFF
--- a/discover/home/core-features/badges.mdx
+++ b/discover/home/core-features/badges.mdx
@@ -17,6 +17,6 @@ Many badges feature multiple tiers - complete all levels to unlock the most pres
 
 - Badges are soulbound NFTs that remain permanently tied to your profile
 - These achievements cannot be transferred or sold
-- Your connected web3 wallet activity can count toward certain badges (see "[Web3 Wallet Activity Support](/discover/Home/getting-started/web3-wallet-activity-support)" for details)
+- Your connected web3 wallet activity can count toward certain badges (see [Web3 Wallet Activity Support](/discover/home/getting-started/web3-wallet-activity-support) for details)
 
 Track your badge progress and view your collection directly from your Sophon Home Profile.

--- a/mint.json
+++ b/mint.json
@@ -185,10 +185,6 @@
       ]
     },
     {
-      "group": "Recipes",
-      "pages": ["sophon-account/recipes/intro"]
-    },
-    {
       "group": "",
       "pages": ["discover/our-universe"]
     },

--- a/sophon-account/authentication/intro.mdx
+++ b/sophon-account/authentication/intro.mdx
@@ -7,29 +7,17 @@ There are some different ways to integrate Sophon Account into your application:
 - Using the **React** and **React Native** SDKs
 - Using the **EIP-6963** standard on *any* web plaform
 
-<Columns cols={3}>
-  <Card
-    title="EIP-6963"
-    icon="globe"
-    href="./eip-6963"
-    arrow="true"
-    cta="Read more"
-  >
+<CardGroup cols={3}>
+  <Card title="EIP-6963" icon="globe" href="./eip6963">
     Fast integration by just importing a package into your existing project.
   </Card>
-  <Card title="React" icon="react" href="./web" arrow="true" cta="Read more">
+  <Card title="React" icon="react" href="./react">
     Integrate any web app with Sophon Account.
   </Card>
-  <Card
-    title="React Native"
-    icon="mobile"
-    href="./react-native"
-    arrow="true"
-    cta="Read more"
-  >
+  <Card title="React Native" icon="mobile" href="./react-native">
     Integrate any mobile app with Sophon Account.
   </Card>
-</Columns>
+</CardGroup>
 
 <Note>
   Some of the options available require a valid `partnerId` to be provided to

--- a/sophon-account/connectors/intro.mdx
+++ b/sophon-account/connectors/intro.mdx
@@ -4,12 +4,10 @@ title: "Overview"
 
 Sophon Account can be used with most popular wallet connectors in the market.
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
 
-<Card title="Viem" icon="square" href="./viem" />
+<Card title="Viem" icon="cube" href="./viem" />
 
 <Card title="Wagmi" icon="cubes" href="./wagmi" />
-
-<Card title="Ethers" icon="code" href="./ethers" />
 
 </CardGroup>

--- a/sophon-account/examples/intro.mdx
+++ b/sophon-account/examples/intro.mdx
@@ -46,7 +46,7 @@ import "@sophon-labs/account-eip6963/testnet";
 <Card
   title="EIP-6963"
   icon="code"
-  href="/sophon-account/examples/web/eip6963"
+  href="https://github.com/sophon-org/sophon-account-sso/tree/main/examples/web/eip6963"
 />
 
 </CardGroup>


### PR DESCRIPTION
- removed recipes section as not used
- fixed the card format in `authentication/intro` (it was not displaying)

Remaining issues running `mint broken-links` @falleco, I don't see the pages needed:
```
sophon-account/connectors/intro.mdx
  ./ethers  
  
sophon-account/examples/intro.mdx
  /sophon-account/examples/web/eip6963 
  ```
  


